### PR TITLE
Add limit option

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ To configure, pass options when you configure the middleware. Currently supporte
 | `decoder`  | a function converting from MessagePack to JavaScript     | `@msgpack/msgpack#decode`                                                    |
 | `encoder`  | a function converting from JavaScript to MessagePack     | `@msgpack/msgpack#encode` (with a wrapper to convert the result to a Buffer) |
 | `mimeType` | the MIME type to detect and set for MessagePack payloads | `"application/msgpack"`                                                      |
+| `limit`    | The byte limit of the body. This is the number of bytes or any string format supported by [bytes](https://www.npmjs.com/package/bytes) | `"100kb"`                                                      |
 
 For example, to switch to the node-gyp C++ based [msgpack] library:
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,9 @@
     "typescript"
   ],
   "author": "Jonathan Sharpe <mail@jonrshar.pe>",
+  "contributors": [
+    "Alan Dzday <dzday@web.de>"
+  ],
   "license": "ISC",
   "bugs": {
     "url": "https://github.com/textbook/express-msgpack/issues"

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -102,4 +102,22 @@ describe("expressMsgpack", () => {
 				});
 		});
 	});
+
+	describe("with a request limit", () => {
+		it("accepts appropriate requests", () => {
+			return request(createApp(msgpack({ limit: "16b" })))
+				.post("/api")
+				.send(raw)
+				.set("Content-Type", "application/msgpack")
+				.expect(200);
+		});
+
+		it("rejects oversized requests", () => {
+			return request(createApp(msgpack({ limit: "1b" })))
+				.post("/api")
+				.send(raw)
+				.set("Content-Type", "application/msgpack")
+				.expect(413);
+		});
+	});
 });

--- a/src/__tests__/unit.test.ts
+++ b/src/__tests__/unit.test.ts
@@ -39,7 +39,7 @@ describe("expressMsgpack", () => {
 
 		await expressMsgpack()(req, res, next);
 
-		expect(readBodyMock).toHaveBeenCalledWith(req, { length: 42 }, expect.any(Function));
+		expect(readBodyMock).toHaveBeenCalledWith(req, { length: 42, limit: "100kb" }, expect.any(Function));
 		const [, , callback] = readBodyMock.mock.calls[0];
 
 		callback(error);
@@ -49,7 +49,7 @@ describe("expressMsgpack", () => {
 	it("handles error decoding the body", async () => {
 		await expressMsgpack()(req, res, next);
 
-		expect(readBodyMock).toHaveBeenCalledWith(req, { length: 42 }, expect.any(Function));
+		expect(readBodyMock).toHaveBeenCalledWith(req, { length: 42, limit: "100kb" }, expect.any(Function));
 		const [, , callback] = readBodyMock.mock.calls[0];
 
 		callback(null, {});
@@ -78,13 +78,19 @@ describe("expressMsgpack", () => {
 
 			await expressMsgpack({ decoder })(req, res, next);
 
-			expect(readBodyMock).toHaveBeenCalledWith(req, { length: 42 }, expect.any(Function));
+			expect(readBodyMock).toHaveBeenCalledWith(req, { length: 42, limit: "100kb" }, expect.any(Function));
 			const [, , callback] = readBodyMock.mock.calls[0];
 
 			callback(null, originalBody);
 			expect(decoder).toHaveBeenCalledWith(originalBody);
 			expect(req).toMatchObject({ body: result, _body: true });
 			expect(next).toHaveBeenCalledWith();
+		});
+
+		it("allows you to change body limit", async () => {
+			await expressMsgpack({ limit: "1mb" })(req, res, next);
+
+			expect(readBodyMock).toHaveBeenCalledWith(req, { length: 42, limit: "1mb" }, expect.any(Function));
 		});
 	});
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export interface ExpressMsgpackOptions {
 	encoder: (body: unknown) => Buffer;
 	decoder: (body: Buffer) => unknown;
 	mimeType: string;
+    limit: string;
 }
 
 export default (overrides: Partial<ExpressMsgpackOptions> = {}): RequestHandler => {
@@ -26,7 +27,7 @@ export default (overrides: Partial<ExpressMsgpackOptions> = {}): RequestHandler 
 			if (new RegExp(`^${options.mimeType}`, "i").test(req.header("Content-Type") ?? "")) {
 				return readBody(
 					req,
-					{ length: req.header("Content-Length") },
+					{ length: req.header("Content-Length"), limit: options.limit },
 					bodyHandler(options, req, next)
 				);
 			}
@@ -61,5 +62,7 @@ const createOptions = async (overrides: Partial<ExpressMsgpackOptions>): Promise
 			?? await import("@msgpack/msgpack").then(({ encode }) => (body) => Buffer.from(encode(body))),
 		mimeType: overrides.mimeType
 			?? "application/msgpack",
+		limit: overrides.limit
+            ?? "100kb",
 	};
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,8 @@ import readBody from "raw-body";
 export interface ExpressMsgpackOptions {
 	encoder: (body: unknown) => Buffer;
 	decoder: (body: Buffer) => unknown;
+	limit: string;
 	mimeType: string;
-    limit: string;
 }
 
 export default (overrides: Partial<ExpressMsgpackOptions> = {}): RequestHandler => {
@@ -60,9 +60,9 @@ const createOptions = async (overrides: Partial<ExpressMsgpackOptions>): Promise
 			?? await import("@msgpack/msgpack").then(({ decode }) => decode),
 		encoder: overrides.encoder
 			?? await import("@msgpack/msgpack").then(({ encode }) => (body) => Buffer.from(encode(body))),
+		limit: overrides.limit
+			?? "100kb",
 		mimeType: overrides.mimeType
 			?? "application/msgpack",
-		limit: overrides.limit
-            ?? "100kb",
 	};
 };


### PR DESCRIPTION
**Description:**

This PR adds a limit option to express-msgpack, allowing users to specify the maximum size of incoming message bodies. This enhances security by mitigating denial-of-service risks.

Let me know if you need further adjustments!
